### PR TITLE
Preserve server state across reloads.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ LOAD_BALANCER_APT_PACKAGES:
   - letsencrypt
   - inotify-tools
   - python3-openssl
+  - socat
 
 LOAD_BALANCER_CERTS_DIR: /etc/haproxy/certs
 LOAD_BALANCER_CONF_DIR: /etc/haproxy/conf.d

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,8 @@ LOAD_BALANCER_BACKEND_MAP: /etc/haproxy/backend.map
 # Path of file used as indicator that haproxy needs to be reloaded.
 LOAD_BALANCER_RELOAD_FILE: /tmp/haproxy-needs-reload
 
+LOAD_BALANCER_STATE_FILE: /tmp/haproxy-server-state
+
 # Whether to use the Let's Encrypt staging server to get certificates.  Enable
 # this for testing to save resources.  The issued certificates won't be
 # accepted by browsers.

--- a/templates/haproxy-reload
+++ b/templates/haproxy-reload
@@ -23,5 +23,7 @@ if [ -f "$HAPROXY_RELOAD_FILE" -o "$1" = "-f" ]; then
         # Exclude editor backup files
         flock -w 1 {{ LOAD_BALANCER_BACKENDS_DIR }} cat {{ LOAD_BALANCER_BACKENDS_DIR }}/*[^~]
     } > {{ LOAD_BALANCER_BACKEND_MAP }}
+    # Dump server state before restart
+    echo "show servers state" | socat /run/haproxy/admin.sock - > {{ LOAD_BALANCER_STATE_FILE }}
     flock -w 1 {{ LOAD_BALANCER_CERTS_DIR }} systemctl reload haproxy
 fi

--- a/templates/haproxy.cfg
+++ b/templates/haproxy.cfg
@@ -4,6 +4,7 @@ global
     chroot /var/lib/haproxy
     stats socket /run/haproxy/admin.sock mode 660 level admin
     stats timeout 2m
+    server-state-file {{ LOAD_BALANCER_STATE_FILE }}
     user haproxy
     group haproxy
     daemon
@@ -29,6 +30,9 @@ defaults
     option httplog
     option dontlognull
     option dontlog-normal
+    option redispatch
+    retries 3
+    load-server-state-from-file global
     timeout connect 5000
     timeout client  50000
     timeout server  50000


### PR DESCRIPTION
These changes make sure the current state of the stick tables is preserved
across reloads.  It also adds options to make sure users get redispatched to a
different backend in case a backend doesn't responde.
