### PR TITLE
Add script to manage haproxy config fragments and bugfix for manage_certs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,25 @@ To add a new backend, perform the following steps:
 1. Create CNAME DNS records for all desired domain names pointing to the load
    balancing server.
 
-2. Add an haproxy configuration fragment to /etc/haproxy/conf.d/ containing the
-   desired backend configuration, e.g.
+2. Create a configuration fragment with the desired backend configuration, e.g.
 
         backend be_example_com
             stick-table type string len 128 size 20k expire 12h
             stick on req.cook(sessionid)
-            server example.com:80 check
+            server srv_example_com example.com:80 check
 
-3. Add a backend map fragment to /etc/haproxy/backends/, containing lines with
-   mappings from domain names to backends, e.g.
+3. Create a backend map fragment containing lines with mappings from domain
+   names to backends, e.g.
 
         example.com be_example_com
         www.example.com be_example.com
 
+4. Copy the configuration and backend map fragments to temporary files on the
+   server and run
+
+        haproxy-config apply <fragment_name> <tmp_config_fragment> <tmp_backend_map_fragment>
+
+   This will replace any fragments with the given fragment name.  To remove the
+   fragment again, use
+
+        haproxy-config remove <fragment_name>

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,4 @@ LETSENCRYPT_FAKE_CERT: /etc/ssl/certs/letsencrypt-fake-cert.crt
 
 LOAD_BALANCER_MANAGE_CERTS_CONF: /etc/manage_certs.conf
 LOAD_BALANCER_MANAGE_CERTS_LOG_LEVEL: info
+LOAD_BALANCER_SNAKE_OIL_CERT: ssl-cert-snakeoil.pem

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,7 @@
     dest: "/usr/local/sbin/{{ item }}"
     mode: "0755"
   with_items:
+    - haproxy-config
     - haproxy-config-watcher
     - haproxy-reload
     - manage_certs.py

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
 - name: copy snakeoil certificate into haproxy config directory
   shell: >
     cat /etc/ssl/certs/ssl-cert-snakeoil.pem /etc/ssl/private/ssl-cert-snakeoil.key \
-        > {{ LOAD_BALANCER_CERTS_DIR }}/ssl-cert-snakeoil.pem
+        > {{ LOAD_BALANCER_CERTS_DIR }}/{{ LOAD_BALANCER_SNAKE_OIL_CERT }}
 
 - name: copy letsencrypt staging certificate for testing purposes
   copy:

--- a/templates/haproxy-config
+++ b/templates/haproxy-config
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# Apply or remove an haproxy configuration fragment.
+
+usage()
+{
+    echo "Usage:"
+    echo "    $0 apply <fragment_name> <config_fragment> <backend_map_fragment>"
+    echo "    $0 remove <fragment_name>"
+    exit 1
+}
+
+case "$1" in
+    apply)
+        if [ "$#" != 4 ]; then
+            usage
+        fi
+        fragment_name="$2"
+        conf_fragment="$3"
+        map_fragment="$4"
+        flock -s "{{ LOAD_BALANCER_CONF_DIR }}" cp "$conf_fragment" "{{ LOAD_BALANCER_CONF_DIR }}/$fragment_name"
+        flock -s "{{ LOAD_BALANCER_BACKENDS_DIR }}" cp "$map_fragment" "{{ LOAD_BALANCER_BACKENDS_DIR }}/$fragment_name"
+        ;;
+    remove)
+        if [ "$#" != 2 ]; then
+            usage
+        fi
+        fragment_name="$2"
+        rm -f "{{ LOAD_BALANCER_CONF_DIR }}/$fragment_name" "{{ LOAD_BALANCER_BACKENDS_DIR }}/$fragment_name"
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/templates/manage_certs.conf
+++ b/templates/manage_certs.conf
@@ -3,6 +3,7 @@
 --haproxy-certs-dir {{ LOAD_BALANCER_CERTS_DIR }}
 --contact-email {{ OPS_EMAIL }}
 --log-level {{ LOAD_BALANCER_MANAGE_CERTS_LOG_LEVEL }}
+--keep-certificate {{ LOAD_BALANCER_SNAKE_OIL_CERT }}
 {% if LETSENCRYPT_USE_STAGING %}
 --letsencrypt-use-staging
 --letsencrypt-fake-cert {{ LETSENCRYPT_FAKE_CERT }}

--- a/templates/manage_certs.py
+++ b/templates/manage_certs.py
@@ -187,6 +187,8 @@ def clean_up_certs(config, all_domains):
     """Remove old certificate files from /etc/letsencrypt."""
     active_domains = set(all_domains)
     for cert_path in config.haproxy_certs_dir.glob("*.pem"):
+        if cert_path.name in config.keep_certificate:
+            continue
         cert = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert_path.read_bytes())
         try:
             dns_names = set(get_dns_names(cert))
@@ -219,6 +221,7 @@ def main(args=sys.argv[1:]):
     parser.add_argument("--letsencrypt-use-staging", action="store_true")
     parser.add_argument("--letsencrypt-fake-cert")
     parser.add_argument("--log-level", default="info")
+    parser.add_argument("--keep-certificate", action="append")
     config = parser.parse_args(args)
 
     logger.setLevel(config.log_level.upper())


### PR DESCRIPTION
This PR contains two unrelated commits:
1. The Ansible script copies the Ubuntu snakeoil certificate into the directory /etc/haproxy/certs because haproxy insists that the directory must contain at least one certificate.  Since we are using the `strict-sni` option, the certificate won't ever be used for anything, but haproxy insists it must be there anyway.
   
   However, when the certificate management script runs for the next time, it will detect that the snakeoil certificate is unused and will duly delete it.  Trying to restart haproxy fails after this happens.  This problem is fixed by this PR.
2. Add a script to manage haproxy config fragments.  This is the API clients use to add, replace and remove fragments.
