### PR TITLE
Only delete certificates issued by Let's Encrypt.

### DIFF
--- a/tests/integration/test.yml
+++ b/tests/integration/test.yml
@@ -33,6 +33,11 @@
         - "{{ LETSENCRYPT_ARCHIVE_DIR }}/{{ TEST_DOMAIN }}"
         - "/etc/letsencrypt/live/{{ TEST_DOMAIN }}"
         - "/etc/letsencrypt/renewal/{{ TEST_DOMAIN }}.conf"
+    - name: create copy of snake oil certificate
+      copy:
+        src: "{{ LOAD_BALANCER_CERTS_DIR }}/{{ LOAD_BALANCER_SNAKE_OIL_CERT }}"
+        dest: "{{ LOAD_BALANCER_CERTS_DIR }}/snakeoil-copy.pem"
+        remote_src: True
     - name: start pydoc as test backend on the server
       become: False
       command: nohup pydoc -p 5000
@@ -50,3 +55,15 @@
           backend be-load-balancer-test
               server srv-pydoc 127.0.0.1:5000
         backend_map_fragment: "{{ TEST_DOMAIN|upper }} be-load-balancer-test\n"
+    - name: stat the snake oil certificate and its copy
+      stat:
+        path: "{{ item }}"
+      register: snake_oil_certs
+      with_items:
+        - "{{ LOAD_BALANCER_CERTS_DIR }}/{{ LOAD_BALANCER_SNAKE_OIL_CERT }}"
+        - "{{ LOAD_BALANCER_CERTS_DIR }}/snakeoil-copy.pem"
+    - name: verify that the snake oil certificate and its copy still exist
+      # They should not be deleted because they were not issued by Let's Encrypt
+      assert:
+        that: item.stat.exists
+      with_items: "{{ snake_oil_certs.results }}"


### PR DESCRIPTION
This makes it easier for us to copy manually issued certificates to the load balancer.  Currently, we need to add the certificate to `/etc/manage_certs.conf` before copying it to the LB to prevent that it gets deleted by the cert manage script.  With this change in place, we only need to copy the cert and are done.

Testing:  The change contains integration test changes that make sure that the feature works as advertised.  If you want to do manual testing, you can do manually what CircleCI does automatically, but I don't see much point in this particular case.