### PR TITLE
Fix bugs with certificate renewal.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ LOAD_BALANCER_CERTS_DIR: /etc/haproxy/certs
 LOAD_BALANCER_CONF_DIR: /etc/haproxy/conf.d
 LOAD_BALANCER_BACKENDS_DIR: /etc/haproxy/backends
 LETSENCRYPT_ARCHIVE_DIR: /etc/letsencrypt/archive
+LETSENCRYPT_LIVE_DIR: /etc/letsencrypt/live
 LOAD_BALANCER_BACKEND_MAP: /etc/haproxy/backend.map
 
 # Path of file used as indicator that haproxy needs to be reloaded.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,7 @@
     - "{{ LOAD_BALANCER_CONF_DIR }}"
     - "{{ LOAD_BALANCER_BACKENDS_DIR }}"
     - "{{ LETSENCRYPT_ARCHIVE_DIR }}"
+    - "{{ LETSENCRYPT_LIVE_DIR }}"
 
 - name: copy haproxy configuration main section
   template:
@@ -48,6 +49,7 @@
     dest: "/usr/local/sbin/{{ item }}"
     mode: "0755"
   with_items:
+    - cert-watcher
     - haproxy-config
     - haproxy-config-watcher
     - haproxy-reload
@@ -58,16 +60,21 @@
     src: manage_certs.conf
     dest: "{{ LOAD_BALANCER_MANAGE_CERTS_CONF }}"
 
-- name: copy config watcher systemd service file
+- name: copy config and cert watcher systemd service files
   template:
-    src: haproxy-config-watcher.service
-    dest: /lib/systemd/system/haproxy-config-watcher.service
-
-- name: enable and start config watcher
-  command: systemctl {{ item }} haproxy-config-watcher
+    src: "{{ item }}"
+    dest: "/lib/systemd/system/{{ item }}"
   with_items:
-    - enable
-    - restart
+    - haproxy-config-watcher.service
+    - cert-watcher.service
+
+- name: enable and start config and cert watcher
+  # The systemd module is only available in Ansible 2.2 or later, so we need to
+  # use command here.
+  command: systemctl {{ item | join(" ") }}
+  with_nested:
+    - ["enable", "restart"]
+    - ["haproxy-config-watcher", "cert-watcher"]
 
 - name: set up cron job to reload haproxy when needed
   cron:
@@ -93,7 +100,7 @@
     # port 443 being in use.  (Seems to be a bug in certbot.)
     job: letsencrypt renew --standalone-supported-challenges http-01 --http-01-port 8080
     hour: "*/12"
-    minute: "?"
+    minute: 42
     cron_file: letsencrypt-renew
     user: root
 

--- a/templates/cert-watcher
+++ b/templates/cert-watcher
@@ -2,6 +2,20 @@
 
 # This script watches for new SSL certificates and installs them to haproxy.
 
+install_cert() {
+    # Certbot behaves differently when renewing a certificate as opposed to
+    # obtaining one for the first time.  The only way I've found to make sure
+    # all files are fully written is to wait some time before actually
+    # installing the certificate.
+    sleep 10
+    cd "{{ LETSENCRYPT_LIVE_DIR }}/$1"
+    # Haproxy expects the certificate and the private key concatenated
+    # together to a single .pem file.  We lock the certs directory to protect
+    # against haproxy reading a half-written certificate.
+    flock {{ LOAD_BALANCER_CERTS_DIR }} cat fullchain.pem privkey.pem \
+          > "{{ LOAD_BALANCER_CERTS_DIR }}/$1.pem"
+}
+
 inotifywait -e create -m -q -r {{ LETSENCRYPT_LIVE_DIR }} |
     while read path event file; do
         case "$file" in
@@ -12,13 +26,7 @@ inotifywait -e create -m -q -r {{ LETSENCRYPT_LIVE_DIR }} |
                 # be created before taking action.
                 domain="${path#{{ LETSENCRYPT_LIVE_DIR }}/}"
                 domain="${domain%/}"
-                cd "{{ LETSENCRYPT_LIVE_DIR }}/$domain"
-                # Haproxy expects the certificate and the private key concatenated
-                # together to a single .pem file.  We lock the certs directory to protect
-                # against haproxy reading a half-written certificate.
-                sleep 20
-                flock {{ LOAD_BALANCER_CERTS_DIR }} cat fullchain.pem privkey.pem \
-                      > "{{ LOAD_BALANCER_CERTS_DIR }}/$domain.pem"
+                install_cert "$domain" &
                 ;;
         esac
     done

--- a/templates/cert-watcher
+++ b/templates/cert-watcher
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# This script watches for new SSL certificates and installs them to haproxy.
+
+inotifywait -e create -m -q -r {{ LETSENCRYPT_LIVE_DIR }} |
+    while read path event file; do
+        case "$file" in
+            fullchain*)
+                # A new certificate was obtained by letsencrypt, either due to periodic
+                # renewal or because a new domain was added.  Letsencrypt writes four .pem
+                # files for each certificate.  We wait for the last one, fullchain.pem, to
+                # be created before taking action.
+                domain="${path#{{ LETSENCRYPT_LIVE_DIR }}/}"
+                domain="${domain%/}"
+                cd "{{ LETSENCRYPT_LIVE_DIR }}/$domain"
+                # Haproxy expects the certificate and the private key concatenated
+                # together to a single .pem file.  We lock the certs directory to protect
+                # against haproxy reading a half-written certificate.
+                sleep 20
+                flock {{ LOAD_BALANCER_CERTS_DIR }} cat fullchain.pem privkey.pem \
+                      > "{{ LOAD_BALANCER_CERTS_DIR }}/$domain.pem"
+                ;;
+        esac
+    done

--- a/templates/cert-watcher.service
+++ b/templates/cert-watcher.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=New certificate watcher for haproxy
+Documentation=https://github.com/open-craft/ansible-load-balancer/README.md
+After=haproxy.service
+
+[Service]
+ExecStart=/usr/local/sbin/cert-watcher
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/haproxy-config-watcher
+++ b/templates/haproxy-config-watcher
@@ -1,44 +1,15 @@
 #!/bin/sh
 
-# This script watches for new SSL certificates or changes to the haproxy
-# configuration files and triggers a reload of haproxy.  The actual reload
-# is performed by the haproxy-reload script.
-
-update_cert()
-{
-    # This is called when a new certificate was obtained by letsencrypt, either
-    # due to periodic renewal or because a new domain was added.  Letsencrypt
-    # writes four .pem files for each certificate.  We wait for the last one,
-    # fullchain.pem, to be closed before taking action.
-    case "$2" in
-        fullchain*)
-            domain="${1#{{ LETSENCRYPT_ARCHIVE_DIR }}/}"
-            domain="${domain%/}"
-            cd /etc/letsencrypt/live/"$domain"
-            # Haproxy expects the certificate and the private key concatenated
-            # together to a single .pem file.  We lock the certs directory to
-            # protect against haproxy reading a half-written certificate.
-            flock {{ LOAD_BALANCER_CERTS_DIR }} cat fullchain.pem privkey.pem \
-                  > "{{ LOAD_BALANCER_CERTS_DIR }}/$domain.pem"
-            ;;
-    esac
-}
+# This script watches for changes to the haproxy configuration files and
+# triggers a reload of haproxy.  The actual reload is performed by the
+# haproxy-reload script.
 
 # It is important to note that haproxy.conf and backend.map are not contained
 # in any of the watched directories, since these files are regenerated upon
-# restart.  Otherwise each restart immediately triggers another restart.
+# restart.  Otherwise each restart would immediately trigger another restart.
 inotifywait -e close_write -e moved_to -e delete -m -q -r \
             {{ LOAD_BALANCER_CERTS_DIR }} {{ LOAD_BALANCER_CONF_DIR }} \
-            {{ LOAD_BALANCER_BACKENDS_DIR }} {{ LETSENCRYPT_ARCHIVE_DIR }} |
+            {{ LOAD_BALANCER_BACKENDS_DIR }} |
     while read path event file; do
-        case "$path" in
-            {{ LETSENCRYPT_ARCHIVE_DIR }}/*)
-                if [ "$event" != "DELETE" ]; then
-                    update_cert "$path" "$file"
-                fi
-                ;;
-            {{ LOAD_BALANCER_CERTS_DIR }}/*|{{ LOAD_BALANCER_CONF_DIR }}/*|{{ LOAD_BALANCER_BACKENDS_DIR }}/*)
-                touch {{ LOAD_BALANCER_RELOAD_FILE }}
-                ;;
-        esac
+        touch {{ LOAD_BALANCER_RELOAD_FILE }}
     done

--- a/templates/manage_certs.py
+++ b/templates/manage_certs.py
@@ -184,7 +184,8 @@ def remove_cert(cert_path):
         logger.info(
             "The certificate %s is not used by any active backend domain.  "
             "However, there is no Let's Encrypt configuration for it, so it is "
-            "not automatically removed."
+            "not automatically removed.",
+            cert_path,
         )
         return
     logger.info(

--- a/tests/integration/test.yml
+++ b/tests/integration/test.yml
@@ -31,7 +31,7 @@
       with_items:
         - "{{ LOAD_BALANCER_CERTS_DIR }}/{{ TEST_DOMAIN }}.pem"
         - "{{ LETSENCRYPT_ARCHIVE_DIR }}/{{ TEST_DOMAIN }}"
-        - "/etc/letsencrypt/live/{{ TEST_DOMAIN }}"
+        - "{{ LETSENCRYPT_LIVE_DIR }}/{{ TEST_DOMAIN }}"
         - "/etc/letsencrypt/renewal/{{ TEST_DOMAIN }}.conf"
     - name: create copy of snake oil certificate
       copy:


### PR DESCRIPTION
* The "?" is not supported by Ubuntu's crond, so use some arbitrary fixed minute.

* When a certificate was renewed, the config watcher picked up the old version in some cases due to a race condition.  This is fixed by watching the live directory instead of the archive directory in the Let's Encrypt config tree.

The integration tests should make sure that this PR does not introduce a regression.  I was unable to write integration tests for the fixed bugs.  Cron seems to ignore errors in the configuration file silently, and I couldn't find a way to validate the cron configuration.  The cron job only runs twice a day, so we can't test that it actually runs in the integration test.  Changing the schedule of the cron job for testing also makes little sense, since it was exactly the schedule that didn't work.

Testing certificate renewal is similarly problematic.  Certificates will be renewed only after 60 days, so unless we want the integration tests to run that long, we can't really test it in the integration tests, and I don't even know an easy way of manually testing this.