### PR TITLE
Remove strict-sni directive

### DIFF
--- a/templates/haproxy.cfg
+++ b/templates/haproxy.cfg
@@ -51,7 +51,7 @@ frontend fe_http
     use_backend be_acme_challenge if acme_challenge
 
 frontend fe_https
-    bind *:443 ssl crt {{ LOAD_BALANCER_CERTS_DIR }} strict-sni
+    bind *:443 ssl crt {{ LOAD_BALANCER_CERTS_DIR }}
     # X-Forwarded-For is added by "option forwardfor"
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https

--- a/templates/manage_certs.py
+++ b/templates/manage_certs.py
@@ -65,7 +65,7 @@ def has_valid_cert(config, domain, ctx=None):
     conn = ctx.wrap_socket(socket.socket(socket.AF_INET), server_hostname=domain)
     try:
         conn.connect(("localhost", 443))
-    except ssl.SSLError:
+    except (ssl.SSLError, ssl.CertificateError):
         return False
     else:
         return True


### PR DESCRIPTION
This PR removes the strict-sni directive from the haproxy config. This is because one of our clients has an integration that uses an HTTP client which doesn't support SNI, and so we can fallback to their certificate as the **first loaded certificate** if an SNI header isn't provided by the HTTP client.

The [haproxy 1.6 crt directive doc](https://cbonte.github.io/haproxy-dconv/1.6/configuration.html#5.1-crt) helpfully states:

> If a directory name is used instead of a PEM file, then **all files found in
that directory will be loaded in alphabetic order** unless their name ends with
'.issuer', '.ocsp' or '.sctl' (reserved extensions).
>
> ....
>
> If no SNI is provided by the client or if the SSL library does not support
TLS extensions, or if the client provides an SNI hostname which does not
match any certificate, then **the first loaded certificate will be presented**.
This means that when loading certificates from a directory, it is highly
recommended to load the default one first as a file or to ensure that it will
always be the first one in the directory.
