### PR TITLE
[WIP] Add TCP health checks and log status changes

### DIFF
--- a/templates/haproxy.cfg
+++ b/templates/haproxy.cfg
@@ -30,6 +30,8 @@ defaults
     option httplog
     option dontlognull
     option dontlog-normal
+    option tcp-check
+    option log-health-checks
     option redispatch
     retries 3
     load-server-state-from-file global


### PR DESCRIPTION
We don't currently appear to have any health checks on HAProxy; we just fail to connect when a request is made. This PR sets up TCP checks by default and logs status changes of servers. I can't find documentation for how often the checks are run for the version of HAProxy that we use; newer versions appear to run every 10 seconds. This is a very low-level check; it just establishes whether we can make a TCP connection to the server.

@smarnach, if you could put your eyes on this and share your thoughts, that would be great.