### PR TITLE
Use the straight ansible_ip for the manage_certs.conf server_ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,18 @@ To run the unit tests, change to the `tests/` subdirectory and run
 
 To run the integration test playbook in `tests/integration.yml`, you need a
 server with a vanilla Ubuntu 16.04 image, and at least one DNS name pointing to
-that server.  DNS changes should already have propagated.  The run
+that server.  DNS changes should already have propagated.
 
-    make test_integration TEST_DOMAIN=test.server.domain
+Create an inventory file containing your test server's hostname and IP address, e.g.,
 
-from the `tests/` subdirectory. Replace test.server.domain with the DNS name of
-your test server.
+    test.server.domain ansible_host=123.45.67.89
+
+Then, from the `tests/` subdirectory, run:
+
+    make test_integration TEST_HOSTS=hosts.test
+
+Replace hosts.test with the path to the inventory file for your test server.
 
 All tests can be run using
 
-    make test TEST_DOMAIN=test.server.domain
+    make test TEST_HOSTS=hosts.test

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
   environment:
     ANSIBLE_REMOTE_USER: ubuntu
     PYTHON27: /opt/circleci/python/2.7.12/bin/python
-    TEST_DOMAIN: haproxy-integration-test.net.opencraft.hosting
+    TEST_HOSTS: integration/hosts
 test:
   override:
     - cd tests && make test

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
-LOAD_BALANCER_SERVER_IP: "{{ lookup('dig', ansible_host) }}"
+LOAD_BALANCER_SERVER_IP: "{{ ansible_host }}"
 
 LOAD_BALANCER_OPS_EMAIL: ops@example.com
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -119,3 +119,7 @@
 
 - name: restart haproxy
   command: /usr/local/sbin/haproxy-reload -f
+
+# Ensures that haproxy logs to /var/log
+- name: restart rsyslog
+  service: name=rsyslog state=restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,7 @@
+- assert:
+    that: LOAD_BALANCER_SERVER_IP | ipaddr
+    msg: "The LOAD_BALANCER_SERVER_IP variable must be an IP address, not a domain name."
+
 - name: install apt packages
   apt:
     name: "{{ item }}"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -23,12 +23,12 @@ test_unit: venv/unit
 	venv/unit/bin/coverage report
 
 test_integration: venv/integration
-	@if [ -z "$(TEST_DOMAIN)" ]; then \
-	    echo "Please set TEST_DOMAIN to the domain name of the test server:"; \
-	    echo "    make $@ TEST_DOMAIN=test.server.domain"; \
+	@if [ -z "$(TEST_HOSTS)" ]; then \
+	    echo "Please set TEST_HOSTS to the inventory file for the test server:"; \
+	    echo "    make $@ TEST_hosts=hosts"; \
 	    false; \
 	fi
-	venv/integration/bin/ansible-playbook -vvv -i "$(TEST_DOMAIN)", integration/test.yml
+	venv/integration/bin/ansible-playbook -vvv -i "$(TEST_HOSTS)" integration/test.yml
 
 update_prospector_config:
 	wget -O pylintrc \

--- a/tests/integration/hosts
+++ b/tests/integration/hosts
@@ -1,0 +1,1 @@
+haproxy-integration-test.net.opencraft.hosting ansible_host=167.114.227.6

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,2 +1,3 @@
 ansible==2.0.1
+netaddr==0.7.19
 dnspython==1.15.0

--- a/tests/integration/test.yml
+++ b/tests/integration/test.yml
@@ -4,7 +4,7 @@
   hosts: all
   gather_facts: false
   tasks:
-    - raw: "[ -e /usr/bin/pyton ] || sudo apt-get update -qq && sudo apt-get install -qq python"
+    - raw: "[ -e /usr/bin/python ] || sudo apt-get update -qq && sudo apt-get install -qq python"
 
 - name: Integration test for the load-balancer role
   hosts: all


### PR DESCRIPTION
Let `LOAD_BALANCER_SERVER_IP` use the `ansible_host` IP address provided for the load balancer server in the inventory file, instead of using `dig` to look it up.

Have also updated the integration tests to use an inventory file, `test/integration/hosts`, so the scenario matches our deployment scenario.

Reasons:
* We're deploying a new load balancer server that will eventually replace the existing one, and so can't use the current domain name.
* When `ansible_hosts` is an IP address, like it is in our deployment services hosts file, running `"{{ lookup('dig', ansible_host) }}"` yields `"NXDOMAIN"`.

**Reviewer**

- [x] @smarnach 