### PR TITLE
Serve maintenance pages from load balancer

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,11 @@ LOAD_BALANCER_SNAKE_OIL_CERT: ssl-cert-snakeoil.pem
 
 # The interval between invocations of manage_certs.py in minutes.
 LOAD_BALANCER_MANAGE_CERTS_INTERVAL: 5
+
+# Configuration for Nginx server serving maintenance pages.
+MAINTENANCE_SERVER_PORT: 8888
+MAINTENANCE_SCHEDULED_SERVER_PORT: "{{ MAINTENANCE_SERVER_PORT + 1 }}"
+MAINTENANCE_UNSCHEDULED_SERVER_PORT: "{{ MAINTENANCE_SERVER_PORT + 2 }}"
+MAINTENANCE_PROVISIONING_SERVER_PORT: "{{ MAINTENANCE_SERVER_PORT + 3 }}"
+MAINTENANCE_SERVER_STATIC_ROOT: /var/www/maintenance
+MAINTENANCE_PAGES_REPO: "https://github.com/open-craft/maintenance-pages"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -108,6 +108,52 @@
     cron_file: letsencrypt-renew
     user: root
 
+- name: Install maintenance backend config
+  template:
+    src: haproxy-maintenance-backends.conf
+    dest: "{{ LOAD_BALANCER_CONF_DIR }}/01-maintenance"
+
+- name: Ensure that {{ MAINTENANCE_SERVER_STATIC_ROOT }} exists
+  file:
+    path: "{{ MAINTENANCE_SERVER_STATIC_ROOT }}"
+    owner: www-data
+    group: www-data
+    state: directory
+
+- name: Install Nginx
+  apt:
+    name: nginx
+  ignore_errors: yes # Port 80 which is used by the default Nginx config is
+                     # already used by HAProxy. This causes a configuration
+                     # error during installation.
+
+- name: Remove default nginx config
+  file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+
+- name: Copy Nginx site configuration
+  template:
+    src: nginx-maintenance.conf
+    dest: /etc/nginx/sites-available/maintenance
+
+- name: Enable Nginx config
+  file:
+    src: /etc/nginx/sites-available/maintenance
+    dest: /etc/nginx/sites-enabled/maintenance
+    state: link
+
+- name: Install maintenance content
+  git:
+    repo: "{{ MAINTENANCE_PAGES_REPO }}"
+    dest: "{{ MAINTENANCE_SERVER_STATIC_ROOT }}/default"
+
+- name: Enable Nginx service and restart
+  service:
+    name: nginx
+    enabled: yes
+    state: restarted
+
 - name: open HTTP and HTTPS port on the firewall
   ufw:
     rule: allow

--- a/templates/haproxy-maintenance-backends.conf
+++ b/templates/haproxy-maintenance-backends.conf
@@ -1,0 +1,21 @@
+# When the AppServer raises the "sinking ship" 50x error this backend gets
+# activated and serves an alternate error page that can be customised
+# per-instance.
+backend error
+    server error-page 127.0.0.1:{{ MAINTENANCE_SERVER_PORT }}
+
+# The following backends can be manually activated during times of scheduled
+# or unscheduled maintenance. The instructions for how to activate them can be
+# found here: https://github.com/open-craft/documentation/blob/master/something_is_down.md
+backend scheduled-maintenance
+    http-response redirect location / unless { capture.req.uri / }
+    server scheduled-maintenance-page 127.0.0.1:{{ MAINTENANCE_SCHEDULED_SERVER_PORT }}
+
+backend unscheduled-maintenance
+    http-response redirect location / unless { capture.req.uri / }
+    server unscheduled-maintenance-page 127.0.0.1:{{ MAINTENANCE_UNSCHEDULED_SERVER_PORT }}
+
+# This backend can be used when an instance is being provisioned
+backend provisioning
+    http-response redirect location / unless { capture.req.uri / }
+    server provisioning-page 127.0.0.1:{{ MAINTENANCE_PROVISIONING_SERVER_PORT }}

--- a/templates/haproxy.cfg
+++ b/templates/haproxy.cfg
@@ -52,10 +52,25 @@ frontend fe_http
 
 frontend fe_https
     bind *:443 ssl crt {{ LOAD_BALANCER_CERTS_DIR }}
+    # Use the error backend if the path begins with /error
+    acl error_mode path_beg /error
+    use_backend error if error_mode
     # X-Forwarded-For is added by "option forwardfor"
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https
+    # If the backend raises a 50x error redirect to /error so the error backend
+    # is used.
+    acl backend_fail status 500:599
+    acl error_backend res.hdr(X-Maintenance) yes
+    http-response redirect location /error if backend_fail !error_backend
     use_backend %[req.hdr(host),lower,map_dom({{ LOAD_BALANCER_BACKEND_MAP }})]
+    # For errors raised by HAProxy redirect to /error so they will go to the
+    # error backend.
+    errorloc 500 /error
+    errorloc 502 /error
+    errorloc 503 /error
+    errorloc 504 /error
+
 
 backend be_acme_challenge
     server srv_lets_encrypt 127.0.0.1:8080

--- a/templates/nginx-maintenance.conf
+++ b/templates/nginx-maintenance.conf
@@ -1,0 +1,96 @@
+server {
+    listen 127.0.0.1:{{ MAINTENANCE_SERVER_PORT }};
+
+    add_header X-Maintenance yes always;
+
+    root {{ MAINTENANCE_SERVER_STATIC_ROOT }};
+
+    server_name _;
+
+    error_page 503 =503 @error;
+
+    location @error {
+        try_files /$host/error.html /default/error.html;
+    }
+
+    location ~ ^/error/static/(.*)$ {
+        try_files /$host/static/$1 /default/static/$1;
+    }
+
+    location = /error {
+        return 503;
+    }
+}
+
+server {
+    listen 127.0.0.1:{{ MAINTENANCE_SCHEDULED_SERVER_PORT }};
+
+    add_header X-Maintenance yes always;
+
+    root {{ MAINTENANCE_SERVER_STATIC_ROOT }};
+
+    server_name _;
+
+    error_page 503 =503 @error;
+
+    location @error {
+        try_files /$host/error.html /default/error.html;
+    }
+
+    location ~ ^/error/static/(.*)$ {
+        try_files /$host/static/$1 /default/static/$1;
+    }
+
+    location = / {
+        return 503;
+    }
+}
+
+server {
+    listen 127.0.0.1:{{ MAINTENANCE_UNSCHEDULED_SERVER_PORT }};
+
+    add_header X-Maintenance yes always;
+
+    root {{ MAINTENANCE_SERVER_STATIC_ROOT }};
+
+    server_name _;
+
+    error_page 503 =503 @error;
+
+    location @error {
+        try_files /$host/error.html /default/error.html;
+    }
+
+    location ~ ^/error/static/(.*)$ {
+        try_files /$host/static/$1 /default/static/$1;
+    }
+
+    location = / {
+        return 503;
+    }
+}
+
+server {
+    listen 127.0.0.1:{{ MAINTENANCE_PROVISIONING_SERVER_PORT }};
+
+    add_header X-Maintenance yes always;
+
+    root {{ MAINTENANCE_SERVER_STATIC_ROOT }};
+
+    server_name _;
+
+    error_page 503 =503 @error;
+
+    location @error {
+        try_files /$host/provisioning.html /default/provisioning.html;
+    }
+
+    location ~ ^/error/static/(.*)$ {
+        try_files /$host/static/$1 /default/static/$1;
+    }
+
+    location = / {
+        return 503;
+    }
+}
+


### PR DESCRIPTION
This pull request configures the load-balancer to serve static content needed for error pages, maintenance pages and preliminary pages.  It also adds HAProxy backends pointing to these backends.  

The ``error`` backend is automatically used in case of a 50x error from an AppServer or if all AppServers fail. The ``*-maintenance`` backends are used in case of maintenance, and the ``provisioning`` backend will eventually be used for instances that are still provisioning. 

The static content is served via an Nginx server that is only exposed locally, with HAProxy in front of it. It is set up to allow host-specific overrides for error and maintenance pages if requested by clients.

**Reviewers**
- [x] @smarnach 