### PR TITLE
reload haproxy with SIGUSR1 instead of SIGUSR2

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,6 +71,7 @@
   with_items:
     - haproxy-config-watcher.service
     - cert-watcher.service
+    - haproxy.service
 
 - name: enable and start config and cert watcher
   # The systemd module is only available in Ansible 2.2 or later, so we need to

--- a/templates/haproxy.service
+++ b/templates/haproxy.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=HAProxy Load Balancer
+Documentation=man:haproxy(1)
+Documentation=file:/usr/share/doc/haproxy/configuration.txt.gz
+After=network.target syslog.service
+Wants=syslog.service
+
+[Service]
+Environment=CONFIG=/etc/haproxy/haproxy.cfg
+EnvironmentFile=-/etc/default/haproxy
+ExecStartPre=/usr/sbin/haproxy -f ${CONFIG} -c -q
+ExecStart=/usr/sbin/haproxy-systemd-wrapper -f ${CONFIG} -p /run/haproxy.pid $EXTRAOPTS
+ExecReload=/usr/sbin/haproxy -c -f ${CONFIG}
+ExecReload=/bin/kill -USR2 $MAINPID
+KillMode=mixed
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/haproxy.service
+++ b/templates/haproxy.service
@@ -11,9 +11,24 @@ EnvironmentFile=-/etc/default/haproxy
 ExecStartPre=/usr/sbin/haproxy -f ${CONFIG} -c -q
 ExecStart=/usr/sbin/haproxy-systemd-wrapper -f ${CONFIG} -p /run/haproxy.pid $EXTRAOPTS
 ExecReload=/usr/sbin/haproxy -c -f ${CONFIG}
-ExecReload=/bin/kill -USR2 $MAINPID
+ExecReload=/bin/kill -USR1 $MAINPID
 KillMode=mixed
 Restart=always
 
 [Install]
 WantedBy=multi-user.target
+
+# The ExecReload kill command uses SIGUSR2 in the default config.
+# 
+# According to the documentation, SIGUSR1 causes a graceful stop of existing 
+# processes.  Once the processes stop, new processes are started to take on 
+# new requests.  
+#
+# SIGUSR2 is intended to be sent to the master process in master-worker mode, 
+# and restarts the worker processes without starting a new master process.
+# 
+# Currently SIGUSR2 is not causing any processes to be collected in production,
+# though it does seem to work on haproxy-dev.
+#
+# Further documentation can be found at:
+# https://www.haproxy.com/documentation/hapee/1-6r2/traffic-management/start-stop-haproxy/


### PR DESCRIPTION
Description goes here. e.g. This PR contains the LibraryContent XBlock, which allows to display library content in a course.

**JIRA tickets**: Proposed fix for [OC-3913](https://tasks.opencraft.com/browse/OC-3913)

**Discussions**: See [OC-3913](https://tasks.opencraft.com/browse/OC-3913) and [OC-1867](https://tasks.opencraft.com/browse/OC-1867)

**Dependencies**: None

**Screenshots**: None

**Sandbox URL**: None.  

**Merge deadline**: None

**Testing instructions**:

1. Deploy a load balancer using the new playbook.  
2. Test that killing any worker process causes all processes to be replaced with new ones.  
3. Test that modifying a config file causes all processes to be replaced (after up to 1 minute).  
4. Test that executing systemctl reload haproxy causes all processes to be replaced.   

**Author notes and concerns**:

I have manually tested that SIGUSR1 reloads haproxy, while SIGUSR2 doesn't, but kept my testing very limited, because I have only been able to reproduce the issue in production.  On haproxy-dev, SIGUSR2 works just as well.  I have not actually tested this with a fresh .service file.

**Reviewers**
- [ ] @clemente 

FYI: @smarnach 
