### PR TITLE
Allow installing HAProxy from a custom PPA

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,11 @@ LOAD_BALANCER_SERVER_IP: "{{ ansible_host }}"
 
 LOAD_BALANCER_OPS_EMAIL: ops@example.com
 
+HAPROXY_PPA: "ppa:vbernat/haproxy-1.8"
+
+HAPROXY_VERSION: "1.8.*"
+
 LOAD_BALANCER_APT_PACKAGES:
-  - haproxy
   - letsencrypt
   - inotify-tools
   - python3-openssl

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,16 @@
     that: LOAD_BALANCER_SERVER_IP | ipaddr
     msg: "The LOAD_BALANCER_SERVER_IP variable must be an IP address, not a domain name."
 
+- name: add HAProxy PPA
+  apt_repository:
+    repo: "{{ HAPROXY_PPA }}"
+  when: HAPROXY_PPA != ""
+
+- name: install HAProxy
+  apt:
+    name: haproxy={{ HAPROXY_VERSION }}
+    state: present
+
 - name: install apt packages
   apt:
     name: "{{ item }}"


### PR DESCRIPTION
This PR makes it possible to install a custom version of HAProxy from a custom PPA. 

**Testing instructions**:
1. Upgrade the installed version of HAProxy using this playbook.
2. Send SIGSEGV to a child HAProxy process.
3. HAProxy should restart gracefully without extended downtime.

**Reviewers**
- [ ] TBD