### PR TITLE
Update CircleCI config to version 2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,18 @@
-machine:
-  python:
-    version: 3.5.2
-  environment:
-    ANSIBLE_REMOTE_USER: ubuntu
-    PYTHON27: /opt/circleci/python/2.7.12/bin/python
-    TEST_HOSTS: integration/hosts
-test:
-  override:
-    - cd tests && make test
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.5.4
+    steps:
+      - checkout
+      - run:
+          command: sudo apt-get update -qq && sudo apt-get install -qq python-dev
+      - run:
+          command: sudo pip install virtualenv
+      - run:
+          name: Run tests
+          command: cd tests && make test
+          environment:
+            TEST_HOSTS: integration/hosts
+            ANSIBLE_HOST_KEY_CHECKING: False
+            ANSIBLE_REMOTE_USER: ubuntu

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,3 +1,3 @@
-ansible==2.0.1
+ansible==2.3.2
 netaddr==0.7.19
 dnspython==1.15.0

--- a/tests/integration/test.yml
+++ b/tests/integration/test.yml
@@ -17,7 +17,7 @@
 
   pre_tasks:
     - assert:
-        that: "lookup('dig', ansible_host) == lookup('dig', TEST_DOMAIN)"
+        that: "ansible_host == lookup('dig', TEST_DOMAIN)"
         msg: "The DNS entry for {{ TEST_DOMAIN }} must point to the test server."
 
   roles:

--- a/tests/integration/test_configuration.yml
+++ b/tests/integration/test_configuration.yml
@@ -22,7 +22,7 @@
 - name: verify that the backend is accessible via HTTPS
   become: False
   local_action: >
-    command wget -O- --ca-certificate=../files/lets-encrypt-fake-cert.crt \
+    command wget -O- --ca-certificate=../../files/lets-encrypt-fake-cert.crt \
           "https://{{ TEST_DOMAIN }}/"
 - name: Remove configuration fragments again
   command: haproxy-config remove test


### PR DESCRIPTION
Migrating to CircleCI version 2.

JIRA Ticket: OC-4053

Testing instructions:

Check that tests are passing.

Note to reviewer:

1. Had to upgrade to python version 3.5.4, since 3.5.2 is not in the list of docker images: https://github.com/CircleCI-Public/circleci-dockerfiles/tree/master/python/images.
2. Had to add ssh-keyscan command since it now checks for host authenticity.
3. Updated pre_tasks assertion for Test domain and ip, not sure why it was working on previous version.

Reviewers:

[Sven]

