### PR TITLE
Add Retry-After headers for web crawlers

### DIFF
--- a/templates/nginx-maintenance.conf
+++ b/templates/nginx-maintenance.conf
@@ -26,6 +26,7 @@ server {
     listen 127.0.0.1:{{ MAINTENANCE_SCHEDULED_SERVER_PORT }};
 
     add_header X-Maintenance yes always;
+    add_header Retry-After 3600 always;  # 1 hour
 
     root {{ MAINTENANCE_SERVER_STATIC_ROOT }};
 
@@ -50,6 +51,7 @@ server {
     listen 127.0.0.1:{{ MAINTENANCE_UNSCHEDULED_SERVER_PORT }};
 
     add_header X-Maintenance yes always;
+    add_header Retry-After 3600 always;  # 1 hour
 
     root {{ MAINTENANCE_SERVER_STATIC_ROOT }};
 


### PR DESCRIPTION
This pull request adds the ``Retry-After`` header to the maintenance and error pages, so web crawlers know when to try reindexing. 

**Testing instructions**:
1. Set up haproxy server with this branch.
2. Check any error page for an backend served by the server.
3. It should have the correct retry-after header.

**Reviewers**
- [ ] @kaizoku 