### PR TITLE
Generate SSL certificate for main domain.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 LOAD_BALANCER_SERVER_IP: "{{ ansible_host }}"
+LOAD_BALANCER_MAIN_DOMAIN: "{{ inventory_hostname }}"
 
 LOAD_BALANCER_OPS_EMAIL: ops@example.com
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -164,4 +164,11 @@
 
 # Ensures that haproxy logs to /var/log
 - name: restart rsyslog
-  service: name=rsyslog state=restarted
+  service:
+    name: rsyslog
+    state: restarted
+
+# Ensure that the certificate for the main domain name of the server is created
+# immediately.  It's needed by the role to install the node exporter.
+- name: run certificate management script
+  command: "/usr/local/sbin/manage_certs.py @{{ LOAD_BALANCER_MANAGE_CERTS_CONF }}"

--- a/templates/manage_certs.conf
+++ b/templates/manage_certs.conf
@@ -4,6 +4,7 @@
 --contact-email {{ LOAD_BALANCER_OPS_EMAIL }}
 --log-level {{ LOAD_BALANCER_MANAGE_CERTS_LOG_LEVEL }}
 --keep-certificate {{ LOAD_BALANCER_SNAKE_OIL_CERT }}
+--additional-domain {{ LOAD_BALANCER_MAIN_DOMAIN }}
 {% if LETSENCRYPT_USE_STAGING %}
 --letsencrypt-use-staging
 --letsencrypt-fake-cert {{ LETSENCRYPT_FAKE_CERT }}

--- a/templates/manage_certs.py
+++ b/templates/manage_certs.py
@@ -12,6 +12,7 @@ removes them and disables the associated Let's Encrypt renewal configuration.
 import argparse
 import collections
 import logging.handlers
+import itertools
 import pathlib
 import shutil
 import socket
@@ -27,7 +28,9 @@ logger = logging.getLogger()
 
 def get_all_domains(config):
     """Get a list of all configured domains from the haproxy backend map."""
-    domains = collections.OrderedDict()
+    # Use integers as dummy backend IDs for the additional domains, to ensure they can
+    # never collide with actual backend names.
+    domains = collections.OrderedDict(zip(config.additional_domain, itertools.count()))
     with config.haproxy_backend_map.open() as backend_map:
         for line in backend_map:
             line = line.strip()
@@ -249,6 +252,7 @@ def parse_command_line(args):
     parser.add_argument("--letsencrypt-fake-cert")
     parser.add_argument("--log-level", default="info")
     parser.add_argument("--keep-certificate", action="append")
+    parser.add_argument("--additional-domain", action="append")
     return parser.parse_args(args)
 
 

--- a/tests/integration/test.yml
+++ b/tests/integration/test.yml
@@ -11,6 +11,9 @@
   become: true
   vars:
     TEST_DOMAIN: "{{ inventory_hostname }}"
+    # To be able to test that the test domain is properly deleted, we need to
+    # set the main domain to a fake value.
+    LOAD_BALANCER_MAIN_DOMAIN: non-existent.domain
     LETSENCRYPT_USE_STAGING: true
     LOAD_BALANCER_MANAGE_CERTS_LOG_LEVEL: debug
     LOAD_BALANCER_MANAGE_CERTS_INTERVAL: 2


### PR DESCRIPTION
The certificate is needed to enable TLS for Prometheus metrics collections.