### PR TITLE
Do not reload old server state after HAProxy restart.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,8 +24,6 @@ LOAD_BALANCER_BACKEND_MAP: /etc/haproxy/backend.map
 # Path of file used as indicator that haproxy needs to be reloaded.
 LOAD_BALANCER_RELOAD_FILE: /tmp/haproxy-needs-reload
 
-LOAD_BALANCER_STATE_FILE: /tmp/haproxy-server-state
-
 # Whether to use the Let's Encrypt staging server to get certificates.  Enable
 # this for testing to save resources.  The issued certificates won't be
 # accepted by browsers.

--- a/templates/haproxy-reload
+++ b/templates/haproxy-reload
@@ -23,8 +23,6 @@ if [ -f "$HAPROXY_RELOAD_FILE" -o "$1" = "-f" ]; then
         # Exclude editor backup files
         flock -w 1 {{ LOAD_BALANCER_BACKENDS_DIR }} cat {{ LOAD_BALANCER_BACKENDS_DIR }}/*[^~]
     } > {{ LOAD_BALANCER_BACKEND_MAP }}
-    # Dump server state before restart
-    echo "show servers state" | socat /run/haproxy/admin.sock - > {{ LOAD_BALANCER_STATE_FILE }}
     if ! flock -w 1 {{ LOAD_BALANCER_CERTS_DIR }} systemctl reload haproxy; then
         # If the restart failed, show useful debugging information that will get included
         # in the error email send by cron.

--- a/templates/haproxy.cfg
+++ b/templates/haproxy.cfg
@@ -4,7 +4,6 @@ global
     chroot /var/lib/haproxy
     stats socket /run/haproxy/admin.sock mode 660 level admin
     stats timeout 2m
-    server-state-file {{ LOAD_BALANCER_STATE_FILE }}
     user haproxy
     group haproxy
     daemon
@@ -32,7 +31,6 @@ defaults
     option dontlog-normal
     option redispatch
     retries 3
-    load-server-state-from-file global
     timeout connect 5000
     timeout client  50000
     timeout server  2m


### PR DESCRIPTION
Reloading the old state is not needed, since we are not using stick tables anymore.  Moreover, reloading the state has caused problems with servers being marked as down forever if they had failing health checks before the restart, and have health checks completely disabled after the restart.  Since no further health checks will be performed, HAProxy will never mark the servers as up again in that case.

We don't strictly need the `socat` package anymore after this change, but since it can still be useful for debugging, I left it in the list of APT packages this role installs.