### PR TITLE
[WIP] Mark certs for delayed deletion.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,10 @@ LOAD_BALANCER_BACKEND_MAP: /etc/haproxy/backend.map
 # Path of file used as indicator that haproxy needs to be reloaded.
 LOAD_BALANCER_RELOAD_FILE: /tmp/haproxy-needs-reload
 
+# Path of folder used to store file markers for domains whose
+# LetsEncrypt cert needs to be deleted.
+LETSENCRYPT_DELETION_MARK_DIR: /tmp/letsencrypt-marked-for-removal
+
 # Whether to use the Let's Encrypt staging server to get certificates.  Enable
 # this for testing to save resources.  The issued certificates won't be
 # accepted by browsers.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,7 @@
     - "{{ LOAD_BALANCER_BACKENDS_DIR }}"
     - "{{ LETSENCRYPT_ARCHIVE_DIR }}"
     - "{{ LETSENCRYPT_LIVE_DIR }}"
+    - "{{ LETSENCRYPT_DELETION_MARK_DIR }}"
 
 - name: copy haproxy configuration main section
   template:
@@ -63,6 +64,7 @@
     mode: "0755"
   with_items:
     - cert-watcher
+    - cert_deleter.py
     - haproxy-config
     - haproxy-config-watcher
     - haproxy-reload
@@ -117,6 +119,14 @@
     hour: "*/12"
     minute: 42
     cron_file: letsencrypt-renew
+    user: root
+
+- name: set up cron job for certificate removal
+  cron:
+    name: "Remove LetsEncrypt certificates that were marked for removal"
+    job: /usr/local/sbin/cert_deleter.py {{ LETSENCRYPT_DELETION_MARK_DIR }}
+    special_time: hourly
+    cron_file: cert-deleter
     user: root
 
 - name: Install maintenance backend config

--- a/templates/cert_deleter.py
+++ b/templates/cert_deleter.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Certificate removal for haproxy load balancing server.
+
+Certificates are marked for removal by the manage_certs.py script.
+Those marks come in the form of file indicators, which this script
+searches for and subsequently uses to help delete those files.
+
+# TODO: There's no functionality yet to unmark a cert for deletion,
+#       in case, for example, the backend comes back online before
+#       the removal date. This should be taken care of in the
+#       manage_certs.py script.
+"""
+
+import datetime
+import os
+import pathlib
+import sys
+import shutil
+import time
+
+
+if __name__ == "__main__":
+    assert len(sys.argv) == 2, "Expects only a directory input to search for " \
+                               "domain names marked for cert deletion."
+
+    deletion_dir = sys.argv[1]
+    for domain in pathlib.Path(deletion_dir).iterdir():
+        # TODO: Make frequency of deletion configurable; it's 15 days by default right now.
+        # TODO: The paths also aren't configurable; they should come from the ansible variables or CLI.
+        if os.path.getctime(domain.as_posix()) < (datetime.datetime.now() - datetime.timedelta(days=15)).timestamp():
+            pathlib.Path("/etc/haproxy/certs", domain.name + ".pem").unlink()
+            pathlib.Path("/etc/letsencrypt/renewal", domain.name + ".conf").unlink()
+            shutil.rmtree("/etc/letsencrypt/live/" + domain.name, ignore_errors=True)
+            shutil.rmtree("/etc/letsencrypt/archive/" + domain.name, ignore_errors=True)
+            domain.unlink()

--- a/templates/manage_certs.conf
+++ b/templates/manage_certs.conf
@@ -1,6 +1,7 @@
 --server-ip {{ LOAD_BALANCER_SERVER_IP }}
 --haproxy-backend-map {{ LOAD_BALANCER_BACKEND_MAP }}
 --haproxy-certs-dir {{ LOAD_BALANCER_CERTS_DIR }}
+--letsencrypt-deletion-mark-dir {{ LETSENCRYPT_DELETION_MARK_DIR }}
 --contact-email {{ LOAD_BALANCER_OPS_EMAIL }}
 --log-level {{ LOAD_BALANCER_MANAGE_CERTS_LOG_LEVEL }}
 --keep-certificate {{ LOAD_BALANCER_SNAKE_OIL_CERT }}


### PR DESCRIPTION
I've decided to use this role for a side project, as it is actually quite generic enough to be used for most use cases easily (e.g. using this to load-balance / proxy / terminate SSL for a k8s cluster).

The only thing that I worried about are those events we had where a certificate was removed after a backend became completely inactive for some reason, in some cases very weird reasons. I think we ultimately figured those issues out, but I still thought we could improve how this role does cert deletions; instead of just straight up removing them if no active backend is available, it should leave them around for a couple days. Thinking about it more though I'm not sure how much that'd buy in terms of safety if the backend is still just down, but I had a WIP branch so I put it up anyway.

Also what about LetsEncrypt wildcard certs? If I was to fork this role for my own use, I'd actually prefer to just drop all the cert-related logic and issue a wildcard cert instead.

cc @smarnach 