### PR TITLE
Introduce HAProxy configuration files with consul-template

### DIFF
--- a/templates/backend.ctmpl
+++ b/templates/backend.ctmpl
@@ -1,0 +1,15 @@
+# This file is auto-generated. Any manual edits will be overwritten.
+
+{{ file "/etc/consul-template/templates/haproxy.cfg" }}
+
+{{- $prefix := "/ocim/instances" }}
+{{- range nodes }}
+{{- $path := (printf "%v@%v" $prefix .Datacenter) }}
+{{ range $ocim_id, $pairs := tree $path | byKey }}
+{{- $domain := "domain_slug" }}
+{{- $load_balanced_domains := (index $pairs "domains").Value | parseJSON }}
+{{- range $load_balanced_domain := $load_balanced_domains }}
+{{ $load_balanced_domain }} be-{{ $domain }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/certs.ctmpl
+++ b/templates/certs.ctmpl
@@ -1,0 +1,11 @@
+# This file is auto-generated. Any manual edits will be overwritten.
+
+{{- $prefix := "certs/" }}
+{{- range nodes }}
+{{- $path := (printf "%v@%v" $prefix .Datacenter) }}
+{{ range tree $path }}
+{{- if .Key | regexMatch "(.*\\.pem)" }}
+{{ .Value }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/haproxy.ctmpl
+++ b/templates/haproxy.ctmpl
@@ -1,0 +1,22 @@
+# This file is auto-generated. Any manual edits will be overwritten.
+
+{{ file "/etc/consul-template/templates/haproxy.cfg" }}
+
+{{- $prefix := "/ocim/instances" }}
+{{- range nodes }}
+{{- $path := (printf "%v@%v" $prefix .Datacenter) }}
+{{ range $ocim_id, $pairs := tree $path | byKey }}
+{{- $server_name := (index $pairs "name").Value | replaceAll " " "_" | toLower }}
+{{- $http_auth_info_base64 := (index $pairs "basic_auth").Value }}
+{{- $active_app_servers := (index $pairs "active_app_servers").Value | parseJSON }}
+{{ $health_check := (index $pairs "health_checks_enabled").Value | parseBool }}
+# Backend configuration for {{ $server_name }}
+cookie openedx-backend insert postonly indirect
+acl has-authorization req.hdr(Authorization) -m found
+http-request set-header Authorization 'Basic {{ $http_auth_info_base64 }}' unless has-authorization
+option httpchk /heartbeat
+{{- range $active_app_servers }}
+server {{ $server_name }} {{ .public_ip }}:80 cookie {{ $server_name }} {{ if $health_check }}check{{ end }}
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Task: [OC-4290](https://tasks.opencraft.com/browse/OC-4290)
This PR introduces some templates that extract Consul configurations and export them into configurations files.

The currently exported documents are:
- haproxy.cfg – Contains a configuration header followed by a loop over the instances with configurations file.
- backend.map – A map of domain names to backend names.
- certs.pem – Generates a single file that contains all the .pem certificates stored under certs/*.pem prefix in consul.
