### PR TITLE
Retry the etckeeper commit a few times.

### DIFF
--- a/templates/haproxy-config
+++ b/templates/haproxy-config
@@ -23,8 +23,11 @@ case "$1" in
               cp "$conf_fragment" "{{ LOAD_BALANCER_CONF_DIR }}/$fragment_name"
         flock -s "{{ LOAD_BALANCER_BACKENDS_DIR }}" \
               awk '{print tolower($1) " " $2}' "$map_fragment" > "{{ LOAD_BALANCER_BACKENDS_DIR }}/$fragment_name"
-        if [ -x "$(command -v etckeeper)" ]; then
-            etckeeper commit 'Auto-commit after "haproxy-config apply".'
+        if [ -x "$(command -v etckeeper)" ] && etckeeper unclean; then
+            for i in 1 2 3; do
+                etckeeper commit 'Auto-commit after "haproxy-config apply".' && break
+                sleep 5
+            done
         fi
         ;;
     remove)
@@ -38,3 +41,4 @@ case "$1" in
         usage
         ;;
 esac
+exit 0


### PR DESCRIPTION
Currently the etckeeper commit can fail for the integration tests if several parallel tests happen to run `etckeeper commit` in parallel.  I wrote this fix for the problem back in May when I noticed it.  I was sure we had a ticket to fix this, but I couldn't find any ticket, and this still isn't merged, so I'm just creating a PR now.