### PR TITLE
[BB-857] Rename exporter vars to lowercase so they can be used as such in lbv2.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,15 +50,15 @@ MAINTENANCE_PAGES_REPO: "https://github.com/open-craft/maintenance-pages"
 
 # PROMETHEUS ##################################################################
 
-HAPROXY_EXPORTER_ENABLED: false
-HAPROXY_EXPORTER_VERSION: 0.9.0
-HAPROXY_EXPORTER_BASENAME: "haproxy_exporter-{{ HAPROXY_EXPORTER_VERSION }}.linux-amd64"
-HAPROXY_EXPORTER_BINARY: "/opt/{{ HAPROXY_EXPORTER_BASENAME }}/haproxy_exporter"
-HAPROXY_EXPORTER_ARCHIVE: "{{ HAPROXY_EXPORTER_BASENAME }}.tar.gz"
-HAPROXY_EXPORTER_DOWNLOAD_URL: "https://github.com/prometheus/haproxy_exporter/releases/download/v{{ HAPROXY_EXPORTER_VERSION }}/{{ HAPROXY_EXPORTER_ARCHIVE }}"
-HAPROXY_EXPORTER_PASSWORD: null
+haproxy_exporter_enabled: false
+haproxy_exporter_version: 0.9.0
+haproxy_exporter_basename: "haproxy_exporter-{{ haproxy_exporter_version }}.linux-amd64"
+haproxy_exporter_binary: "/opt/{{ haproxy_exporter_basename }}/haproxy_exporter"
+haproxy_exporter_archive: "{{ haproxy_exporter_basename }}.tar.gz"
+haproxy_exporter_download_url: "https://github.com/prometheus/haproxy_exporter/releases/download/v{{ haproxy_exporter_version }}/{{ haproxy_exporter_archive }}"
+haproxy_exporter_password: null
 
-HAPROXY_EXPORTER_CONSUL_SERVICE:
+haproxy_exporter_consul_service:
   service:
     name: haproxy-exporter
     tags:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,12 +2,12 @@
 
 dependencies:
   - name: nginx-proxy
-    when: HAPROXY_EXPORTER_ENABLED
+    when: haproxy_exporter_enabled
     # The username is a bit misleading – should actually be "prometheus", since it's the server
     # authenticating, and the same username is used for scraping other exporters, but it's not worth
     # the hassle to change it.
     NGINX_PROXY_USERNAME: node-exporter
-    NGINX_PROXY_PASSWORD: "{{ HAPROXY_EXPORTER_PASSWORD }}"
+    NGINX_PROXY_PASSWORD: "{{ haproxy_exporter_password }}"
     NGINX_PROXY_AUTH_DOMAIN: Prometheus HAProxy Exporter
     NGINX_PROXY_CONFIG_PATH: /etc/nginx/sites-available/haproxy-exporter
     NGINX_PROXY_PUBLIC_PORT: 19101

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -179,15 +179,15 @@
     creates: "/etc/letsencrypt/live/{{ LOAD_BALANCER_MAIN_DOMAIN }}"
 
 - name: Install Prometheus HAProxy exporter
-  when: HAPROXY_EXPORTER_ENABLED
+  when: haproxy_exporter_enabled
   block:
 
     - name: Download HAProxy exporter
       unarchive:
-        src: "{{ HAPROXY_EXPORTER_DOWNLOAD_URL }}"
+        src: "{{ haproxy_exporter_download_url }}"
         remote_src: yes
         dest: /opt
-        creates: "{{ HAPROXY_EXPORTER_BINARY }}"
+        creates: "{{ haproxy_exporter_binary }}"
 
     - name: Copy HAProxy exporter service definition
       template:
@@ -203,7 +203,7 @@
 
     - name: Create Consul service definition file
       copy:
-        content: "{{ HAPROXY_EXPORTER_CONSUL_SERVICE | to_nice_json }}"
+        content: "{{ haproxy_exporter_consul_service | to_nice_json }}"
         dest: /etc/consul/haproxy-exporter.json
       notify:
         - reload consul

--- a/templates/haproxy-exporter.service.j2
+++ b/templates/haproxy-exporter.service.j2
@@ -3,7 +3,7 @@ Description=Prometheus HAProxy Exporter
 After=network-online.target
 
 [Service]
-ExecStart={{ HAPROXY_EXPORTER_BINARY }} --web.listen-address 127.0.0.1:9101 --haproxy.scrape-uri=unix:/run/haproxy/admin.sock
+ExecStart={{ haproxy_exporter_binary }} --web.listen-address 127.0.0.1:9101 --haproxy.scrape-uri=unix:/run/haproxy/admin.sock
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
Not strictly necessary, but I wanted to get off to a consistent start with lbv2 naming.