### PR TITLE
[SE-1328] Reduce email sent by certbot

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -115,7 +115,7 @@
     # reuses the parameters used when a certificate was issued for the last time.
     # However, not passing in the port results in letsencrypt complaining about
     # port 443 being in use.  (Seems to be a bug in certbot.)
-    job: letsencrypt renew --standalone-supported-challenges http-01 --http-01-port 8080
+    job: "letsencrypt renew --preferred-challenges http-01 --http-01-port 8080 >/dev/null 2>&1"
     hour: "*/12"
     minute: 42
     cron_file: letsencrypt-renew

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -115,7 +115,7 @@
     # reuses the parameters used when a certificate was issued for the last time.
     # However, not passing in the port results in letsencrypt complaining about
     # port 443 being in use.  (Seems to be a bug in certbot.)
-    job: "letsencrypt renew --preferred-challenges http-01 --http-01-port 8080 >/dev/null 2>&1"
+    job: "letsencrypt renew --standalone-supported-challenges http-01 --http-01-port 8080 -q"
     hour: "*/12"
     minute: 42
     cron_file: letsencrypt-renew


### PR DESCRIPTION
There are two commits on this branch.

One is a `-q` flag which can be merged in if it causes no problems on stage. (I am testing it now.)

The other is a redirection to /dev/null which can be cherry-picked later if needed. The `-q` flag does not silence errors and we are getting a lot of nuisance messages for domains that don't exist. This might be cleared up once the new load balancers are deployed and it would be nice to keep messages about real failures going to ops@. If not, that's what `e27756f` is for. :)